### PR TITLE
Add devlink events monitoring

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,9 @@ endif
 if WITH_EXTLOG
    rasdaemon_SOURCES += ras-extlog-handler.c
 endif
+if WITH_DEVLINK
+   rasdaemon_SOURCES += ras-devlink-handler.c
+endif
 if WITH_ABRT_REPORT
    rasdaemon_SOURCES += ras-report.c
 endif
@@ -52,7 +55,8 @@ rasdaemon_LDADD = -lpthread $(SQLITE3_LIBS) libtrace/libtrace.a
 
 include_HEADERS = config.h  ras-events.h  ras-logger.h  ras-mc-handler.h \
 		  ras-aer-handler.h ras-mce-handler.h ras-record.h bitfield.h ras-report.h \
-		  ras-extlog-handler.h ras-arm-handler.h ras-non-standard-handler.h
+		  ras-extlog-handler.h ras-arm-handler.h ras-non-standard-handler.h \
+		  ras-devlink-handler.h
 
 # This rule can't be called with more than one Makefile job (like make -j8)
 # I can't figure out a way to fix that

--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,15 @@ AS_IF([test "x$enable_extlog" = "xyes"], [
 ])
 AM_CONDITIONAL([WITH_EXTLOG], [test x$enable_extlog = xyes])
 
+AC_ARG_ENABLE([devlink],
+    AS_HELP_STRING([--enable-devlink], [enable devlink health events (currently experimental)]))
+
+AS_IF([test "x$enable_devlink" = "xyes"], [
+  AC_DEFINE(HAVE_DEVLINK,1,"have devlink health events collect")
+  AC_SUBST([WITH_DEVLINK])
+])
+AM_CONDITIONAL([WITH_DEVLINK], [test x$enable_devlink = xyes])
+
 AC_ARG_ENABLE([abrt_report],
     AS_HELP_STRING([--enable-abrt-report], [enable report event to ABRT (currently experimental)]))
 
@@ -127,4 +136,5 @@ compile time options summary
     ABRT report         : $enable_abrt_report
     HIP07 SAS HW errors : $enable_hisi_ns_decode
     ARM events          : $enable_arm
+    DEVLINK             : $enable_devlink
 EOF

--- a/libtrace/parse-filter.c
+++ b/libtrace/parse-filter.c
@@ -1720,17 +1720,25 @@ static const char *get_field_str(struct filter_arg *arg, struct pevent_record *r
 	struct pevent *pevent;
 	unsigned long long addr;
 	const char *val = NULL;
+	unsigned int size;
 	char hex[64];
 
 	/* If the field is not a string convert it */
 	if (arg->str.field->flags & FIELD_IS_STRING) {
 		val = record->data + arg->str.field->offset;
+		size = arg->str.field->size;
+
+		if (arg->str.field->flags & FIELD_IS_DYNAMIC) {
+			addr = *(unsigned int *)val;
+			val = record->data + (addr & 0xffff);
+			size = addr >> 16;
+		}
 
 		/*
 		 * We need to copy the data since we can't be sure the field
 		 * is null terminated.
 		 */
-		if (*(val + arg->str.field->size - 1)) {
+		if (*(val + size - 1)) {
 			/* copy it */
 			memcpy(arg->str.buffer, val, arg->str.field->size);
 			/* the buffer is already NULL terminated */

--- a/ras-devlink-handler.c
+++ b/ras-devlink-handler.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2019 Cong Wang <xiyou.wangcong@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "libtrace/kbuffer.h"
+#include "ras-devlink-handler.h"
+#include "ras-record.h"
+#include "ras-logger.h"
+#include "ras-report.h"
+
+int ras_devlink_event_handler(struct trace_seq *s,
+			      struct pevent_record *record,
+			      struct event_format *event, void *context)
+{
+	int len;
+	struct ras_events *ras = context;
+	time_t now;
+	struct tm *tm;
+	struct devlink_event ev;
+
+	/*
+	 * Newer kernels (3.10-rc1 or upper) provide an uptime clock.
+	 * On previous kernels, the way to properly generate an event would
+	 * be to inject a fake one, measure its timestamp and diff it against
+	 * gettimeofday. We won't do it here. Instead, let's use uptime,
+	 * falling-back to the event report's time, if "uptime" clock is
+	 * not available (legacy kernels).
+	 */
+
+	if (ras->use_uptime)
+		now = record->ts/user_hz + ras->uptime_diff;
+	else
+		now = time(NULL);
+
+	tm = localtime(&now);
+	if (tm)
+		strftime(ev.timestamp, sizeof(ev.timestamp),
+			 "%Y-%m-%d %H:%M:%S %z", tm);
+	trace_seq_printf(s, "%s ", ev.timestamp);
+
+	ev.bus_name = pevent_get_field_raw(s, event, "bus_name",
+					   record, &len, 1);
+	if (!ev.bus_name)
+		return -1;
+
+	ev.dev_name = pevent_get_field_raw(s, event, "dev_name",
+					   record, &len, 1);
+	if (!ev.dev_name)
+		return -1;
+
+	ev.driver_name = pevent_get_field_raw(s, event, "driver_name",
+					   record, &len, 1);
+	if (!ev.driver_name)
+		return -1;
+
+	ev.reporter_name = pevent_get_field_raw(s, event, "reporter_name",
+					   record, &len, 1);
+	if (!ev.reporter_name)
+		return -1;
+
+	ev.msg = pevent_get_field_raw(s, event, "msg", record, &len, 1);
+	if (!ev.msg)
+		return -1;
+
+	/* Insert data into the SGBD */
+#ifdef HAVE_SQLITE3
+	ras_store_devlink_event(ras, &ev);
+#endif
+
+#ifdef HAVE_ABRT_REPORT
+	/* Report event to ABRT */
+	ras_report_devlink_event(ras, &ev);
+#endif
+
+	return 0;
+}

--- a/ras-devlink-handler.h
+++ b/ras-devlink-handler.h
@@ -22,6 +22,10 @@
 #include "ras-events.h"
 #include "libtrace/event-parse.h"
 
+int ras_net_xmit_timeout_handler(struct trace_seq *s,
+				 struct pevent_record *record,
+				 struct event_format *event, void *context);
+
 int ras_devlink_event_handler(struct trace_seq *s,
 			      struct pevent_record *record,
 			      struct event_format *event, void *context);

--- a/ras-devlink-handler.h
+++ b/ras-devlink-handler.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 Cong Wang <xiyou.wangcong@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#ifndef __RAS_DEVLINK_HANDLER_H
+#define __RAS_DEVLINK_HANDLER_H
+
+#include "ras-events.h"
+#include "libtrace/event-parse.h"
+
+int ras_devlink_event_handler(struct trace_seq *s,
+			      struct pevent_record *record,
+			      struct event_format *event, void *context);
+
+#endif

--- a/ras-events.c
+++ b/ras-events.c
@@ -570,10 +570,11 @@ static int select_tracing_timestamp(struct ras_events *ras)
 
 static int add_event_handler(struct ras_events *ras, struct pevent *pevent,
 			     unsigned page_size, char *group, char *event,
-			     pevent_event_handler_func func)
+			     pevent_event_handler_func func, char *filter_str)
 {
 	int fd, size, rc;
 	char *page, fname[MAX_PATH + 1];
+	struct event_filter * filter = NULL;
 
 	snprintf(fname, sizeof(fname), "events/%s/%s/format", group, event);
 
@@ -618,6 +619,28 @@ static int add_event_handler(struct ras_events *ras, struct pevent *pevent,
 		return EINVAL;
 	}
 
+	if (filter_str) {
+		char *error;
+
+		filter = pevent_filter_alloc(pevent);
+		if (!filter) {
+			log(TERM, LOG_ERR,
+			    "Failed to allocate filter for %s/%s.\n", group, event);
+			free(page);
+			return EINVAL;
+		}
+		rc = pevent_filter_add_filter_str(filter, filter_str, &error);
+		if (rc) {
+			log(TERM, LOG_ERR,
+			    "Failed to install filter for %s/%s: %s\n", group, event, error);
+			pevent_filter_free(filter);
+			free(page);
+			return rc;
+		}
+	}
+
+	ras->filter = filter;
+
 	/* Enable RAS events */
 	rc = __toggle_ras_mc_event(ras, group, event, 1);
 	if (rc < 0) {
@@ -641,6 +664,7 @@ int handle_ras_events(int record_events)
 	struct pevent *pevent = NULL;
 	struct pthread_data *data = NULL;
 	struct ras_events *ras = NULL;
+	char *filter_str = NULL;
 
 	ras = calloc(1, sizeof(*ras));
 	if (!ras) {
@@ -674,7 +698,7 @@ int handle_ras_events(int record_events)
 	ras->record_events = record_events;
 
 	rc = add_event_handler(ras, pevent, page_size, "ras", "mc_event",
-			       ras_mc_event_handler);
+			       ras_mc_event_handler, NULL);
 	if (!rc)
 		num_events++;
 	else
@@ -683,7 +707,7 @@ int handle_ras_events(int record_events)
 
 #ifdef HAVE_AER
 	rc = add_event_handler(ras, pevent, page_size, "ras", "aer_event",
-			       ras_aer_event_handler);
+			       ras_aer_event_handler, NULL);
 	if (!rc)
 		num_events++;
 	else
@@ -693,7 +717,7 @@ int handle_ras_events(int record_events)
 
 #ifdef HAVE_NON_STANDARD
         rc = add_event_handler(ras, pevent, page_size, "ras", "non_standard_event",
-                               ras_non_standard_event_handler);
+                               ras_non_standard_event_handler, NULL);
         if (!rc)
                 num_events++;
         else
@@ -703,7 +727,7 @@ int handle_ras_events(int record_events)
 
 #ifdef HAVE_ARM
         rc = add_event_handler(ras, pevent, page_size, "ras", "arm_event",
-                               ras_arm_event_handler);
+                               ras_arm_event_handler, NULL);
         if (!rc)
                 num_events++;
         else
@@ -720,7 +744,7 @@ int handle_ras_events(int record_events)
 	if (ras->mce_priv) {
 		rc = add_event_handler(ras, pevent, page_size,
 				       "mce", "mce_record",
-			               ras_mce_event_handler);
+			               ras_mce_event_handler, NULL);
 		if (!rc)
 			num_events++;
 	else
@@ -731,7 +755,7 @@ int handle_ras_events(int record_events)
 
 #ifdef HAVE_EXTLOG
 	rc = add_event_handler(ras, pevent, page_size, "ras", "extlog_mem_event",
-			       ras_extlog_mem_event_handler);
+			       ras_extlog_mem_event_handler, NULL);
 	if (!rc) {
 		/* tell kernel we are listening, so don't printk to console */
 		(void)open("/sys/kernel/debug/ras/daemon_active", 0);
@@ -742,9 +766,15 @@ int handle_ras_events(int record_events)
 #endif
 
 #ifdef HAVE_DEVLINK
+	rc = add_event_handler(ras, pevent, page_size, "net",
+			       "net_dev_xmit_timeout",
+			       ras_net_xmit_timeout_handler, NULL);
+        if (!rc)
+		filter_str = "devlink/devlink_health_report:msg=~\'TX timeout*\'";
+
 	rc = add_event_handler(ras, pevent, page_size, "devlink",
 			       "devlink_health_report",
-			       ras_devlink_event_handler);
+			       ras_devlink_event_handler, filter_str);
         if (!rc)
                 num_events++;
         else
@@ -801,8 +831,11 @@ err:
 	if (pevent)
 		pevent_free(pevent);
 
-	if (ras)
+	if (ras) {
+		if (ras->filter)
+			pevent_filter_free(ras->filter);
 		free(ras);
+	}
 
 	return rc;
 }

--- a/ras-events.c
+++ b/ras-events.c
@@ -33,6 +33,7 @@
 #include "ras-arm-handler.h"
 #include "ras-mce-handler.h"
 #include "ras-extlog-handler.h"
+#include "ras-devlink-handler.h"
 #include "ras-record.h"
 #include "ras-logger.h"
 
@@ -216,6 +217,10 @@ int toggle_ras_mc_event(int enable)
 
 #ifdef HAVE_ARM
 	rc |= __toggle_ras_mc_event(ras, "ras", "arm_event", enable);
+#endif
+
+#ifdef HAVE_DEVLINK
+	rc |= __toggle_ras_mc_event(ras, "devlink", "devlink_health_report", enable);
 #endif
 
 free_ras:
@@ -734,6 +739,17 @@ int handle_ras_events(int record_events)
 	} else
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "ras", "aer_event");
+#endif
+
+#ifdef HAVE_DEVLINK
+	rc = add_event_handler(ras, pevent, page_size, "devlink",
+			       "devlink_health_report",
+			       ras_devlink_event_handler);
+        if (!rc)
+                num_events++;
+        else
+                log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
+                    "devlink", "devlink_health_report");
 #endif
 
 	if (!num_events) {

--- a/ras-events.h
+++ b/ras-events.h
@@ -50,6 +50,8 @@ struct ras_events {
 
 	/* For ABRT socket*/
 	int socketfd;
+
+	struct event_filter *filter;
 };
 
 struct pthread_data {

--- a/ras-record.h
+++ b/ras-record.h
@@ -75,12 +75,22 @@ struct ras_arm_event {
 	int32_t psci_state;
 };
 
+struct devlink_event {
+	char timestamp[64];
+	const char *bus_name;
+	const char *dev_name;
+	const char *driver_name;
+	const char *reporter_name;
+	const char *msg;
+};
+
 struct ras_mc_event;
 struct ras_aer_event;
 struct ras_extlog_event;
 struct ras_non_standard_event;
 struct ras_arm_event;
 struct mce_event;
+struct devlink_event;
 
 #ifdef HAVE_SQLITE3
 
@@ -104,6 +114,9 @@ struct sqlite3_priv {
 #ifdef HAVE_ARM
 	sqlite3_stmt	*stmt_arm_record;
 #endif
+#ifdef HAVE_DEVLINK
+	sqlite3_stmt	*stmt_devlink_event;
+#endif
 };
 
 int ras_mc_event_opendb(unsigned cpu, struct ras_events *ras);
@@ -113,6 +126,7 @@ int ras_store_mce_record(struct ras_events *ras, struct mce_event *ev);
 int ras_store_extlog_mem_record(struct ras_events *ras, struct ras_extlog_event *ev);
 int ras_store_non_standard_record(struct ras_events *ras, struct ras_non_standard_event *ev);
 int ras_store_arm_record(struct ras_events *ras, struct ras_arm_event *ev);
+int ras_store_devlink_event(struct ras_events *ras, struct devlink_event *ev);
 
 #else
 static inline int ras_mc_event_opendb(unsigned cpu, struct ras_events *ras) { return 0; };
@@ -122,6 +136,7 @@ static inline int ras_store_mce_record(struct ras_events *ras, struct mce_event 
 static inline int ras_store_extlog_mem_record(struct ras_events *ras, struct ras_extlog_event *ev) { return 0; };
 static inline int ras_store_non_standard_record(struct ras_events *ras, struct ras_non_standard_event *ev) { return 0; };
 static inline int ras_store_arm_record(struct ras_events *ras, struct ras_arm_event *ev) { return 0; };
+static inline int ras_store_devlink_event(struct ras_events *ras, struct devlink_event *ev) { return 0; };
 
 #endif
 

--- a/ras-record.h
+++ b/ras-record.h
@@ -81,7 +81,7 @@ struct devlink_event {
 	const char *dev_name;
 	const char *driver_name;
 	const char *reporter_name;
-	const char *msg;
+	char *msg;
 };
 
 struct ras_mc_event;

--- a/ras-report.c
+++ b/ras-report.c
@@ -256,6 +256,31 @@ static int set_arm_event_backtrace(char *buf, struct ras_arm_event *ev){
 	return 0;
 }
 
+static int set_devlink_event_backtrace(char *buf, struct devlink_event *ev){
+	char bt_buf[MAX_BACKTRACE_SIZE];
+
+	if(!buf || !ev)
+		return -1;
+
+	sprintf(bt_buf, "BACKTRACE="	\
+						"timestamp=%s\n"	\
+						"bus_name=%s\n"		\
+						"dev_name=%s\n"		\
+						"driver_name=%s\n"	\
+						"reporter_name=%s\n"	\
+						"msg=%s\n",		\
+						ev->timestamp,		\
+						ev->bus_name,		\
+						ev->dev_name,		\
+						ev->driver_name,	\
+						ev->reporter_name,	\
+						ev->msg);
+
+	strcat(buf, bt_buf);
+
+	return 0;
+}
+
 static int commit_report_backtrace(int sockfd, int type, void *ev){
 	char buf[MAX_BACKTRACE_SIZE];
 	char *pbuf = buf;
@@ -283,6 +308,9 @@ static int commit_report_backtrace(int sockfd, int type, void *ev){
 		break;
 	case ARM_EVENT:
 		rc = set_arm_event_backtrace(buf, (struct ras_arm_event *)ev);
+		break;
+	case DEVLINK_EVENT:
+		rc = set_devlink_event_backtrace(buf, (struct devlink_event *)ev);
 		break;
 	default:
 		return -1;
@@ -539,6 +567,56 @@ int ras_report_mce_event(struct ras_events *ras, struct mce_event *ev){
 	done = 1;
 
 mce_fail:
+
+	if(sockfd > 0){
+		close(sockfd);
+	}
+
+	if(done){
+		return 0;
+	}else{
+		return -1;
+	}
+}
+
+int ras_report_devlink_event(struct ras_events *ras, struct devlink_event *ev){
+	char buf[MAX_MESSAGE_SIZE];
+	int sockfd = 0;
+	int done = 0;
+	int rc = -1;
+
+	memset(buf, 0, sizeof(buf));
+
+	sockfd = setup_report_socket();
+	if(sockfd < 0){
+		return -1;
+	}
+
+	rc = commit_report_basic(sockfd);
+	if(rc < 0){
+		goto devlink_fail;
+	}
+
+	rc = commit_report_backtrace(sockfd, DEVLINK_EVENT, ev);
+	if(rc < 0){
+		goto devlink_fail;
+	}
+
+	sprintf(buf, "ANALYZER=%s", "rasdaemon-devlink");
+	rc = write(sockfd, buf, strlen(buf) + 1);
+	if(rc < strlen(buf) + 1){
+		goto devlink_fail;
+	}
+
+	sprintf(buf, "REASON=%s", "devlink health report problem");
+	rc = write(sockfd, buf, strlen(buf) + 1);
+	if(rc < strlen(buf) + 1){
+		goto devlink_fail;
+	}
+
+	done = 1;
+
+devlink_fail:
 
 	if(sockfd > 0){
 		close(sockfd);

--- a/ras-report.h
+++ b/ras-report.h
@@ -34,7 +34,8 @@ enum {
 	MCE_EVENT,
 	AER_EVENT,
 	NON_STANDARD_EVENT,
-	ARM_EVENT
+	ARM_EVENT,
+	DEVLINK_EVENT
 };
 
 #ifdef HAVE_ABRT_REPORT
@@ -44,6 +45,7 @@ int ras_report_aer_event(struct ras_events *ras, struct ras_aer_event *ev);
 int ras_report_mce_event(struct ras_events *ras, struct mce_event *ev);
 int ras_report_non_standard_event(struct ras_events *ras, struct ras_non_standard_event *ev);
 int ras_report_arm_event(struct ras_events *ras, struct ras_arm_event *ev);
+int ras_report_devlink_event(struct ras_events *ras, struct devlink_event *ev);
 
 #else
 
@@ -52,6 +54,7 @@ static inline int ras_report_aer_event(struct ras_events *ras, struct ras_aer_ev
 static inline int ras_report_mce_event(struct ras_events *ras, struct mce_event *ev) { return 0; };
 static inline int ras_report_non_standard_event(struct ras_events *ras, struct ras_non_standard_event *ev) { return 0; };
 static inline int ras_report_arm_event(struct ras_events *ras, struct ras_arm_event *ev) { return 0; };
+static inline int ras_report_devlink_event(struct ras_events *ras, struct devlink_event *ev) { return 0; };
 
 #endif
 

--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -1175,6 +1175,22 @@ sub summary
     }
     $query_handle->finish;
 
+    # devlink errors
+    $query = "select dev_name, count(*) from devlink_event group by dev_name";
+    $query_handle = $dbh->prepare($query);
+    $query_handle->execute();
+    $query_handle->bind_columns(\($dev_name, $count));
+    $out = "";
+    while($query_handle->fetch()) {
+        $out .= "\t$dev_name has $count errors\n";
+    }
+    if ($out ne "") {
+        print "Devlink records summary:\n$out";
+    } else {
+        print "No devlink errors.\n";
+    }
+    $query_handle->finish;
+
     # MCE mce_record errors
     $query = "select error_msg, count(*) from mce_record group by error_msg";
     $query_handle = $dbh->prepare($query);
@@ -1261,6 +1277,28 @@ sub errors
         print "Extlog events:\n$out\n";
     } else {
         print "No Extlog errors.\n\n";
+    }
+    $query_handle->finish;
+
+    # devlink errors
+    $query = "select id, timestamp, bus_name, dev_name, driver_name, reporter_name, msg from devlink_event order by id";
+    $query_handle = $dbh->prepare($query);
+    $query_handle->execute();
+    $query_handle->bind_columns(\($id, $timestamp, $bus_name, $dev_name, $driver_name, $reporter_name, $msg));
+    $out = "";
+    while($query_handle->fetch()) {
+        $out .= "$id $timestamp error: ";
+        $out .= "bus_name=$bus_name, ";
+        $out .= "dev_name=$dev_name, ";
+        $out .= "driver_name=$driver_name, ";
+        $out .= "reporter_name=$reporter_name, ";
+        $out .= "message='$msg', ";
+        $out .= "\n";
+    }
+    if ($out ne "") {
+        print "Devlink events:\n$out\n";
+    } else {
+        print "No devlink errors.\n\n";
     }
     $query_handle->finish;
 


### PR DESCRIPTION
This PR adds devlink events monitoring to rasdaemon.

devlink trace events are for network interface errors like PCI error, TX queue timeout. Linux kernel provides tracepoint devlink/devlink_health_report for this purpose, but this is driver-specific and currently only mlx5 driver supports it. net/net_dev_xmit_timeout is introduced recently as a general purpose tracepoint. So, the logic here is when we have net/net_dev_xmit_timeout we should use it to replace TX timeout reports from devlink/devlink_health_report, therefore we need to filter them out.

The last commit in this PR is a bug fix backported from libtraceevent, as rasdaemon carries a copy of libtrace.

I have tested it with trace event injection. It works as expected.